### PR TITLE
Additional BS444 BT Identifier

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -69,7 +69,7 @@ public class BluetoothFactory {
             return new BluetoothIhealthHS3(context);
         }
         // BS444 || BS440
-        if (deviceName.startsWith("013197") || deviceName.startsWith("0202B6")) {
+        if (deviceName.startsWith("013197") || deviceName.startsWith("013198") || deviceName.startsWith("0202B6")) {
             return new BluetoothMedisanaBS44x(context, true);
         }
 


### PR DESCRIPTION
Added additional BT identifier/name for Medisana BS444 model (currently unrecognized in openScale Pro app), not entirely sure whether the current code works, please check.